### PR TITLE
Refactor prototypes into classes

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,206 +30,206 @@ var rdf = require('rdf-ext')
 
 const readFile = util.promisify(fs.readFile)
 
-// SHACL Interface
 /**
- * SHACL Validator.
- * Main interface with the library
+ * Validates RDF data based on a set of RDF shapes.
  */
-var SHACLValidator = function () {
-  this.$data = new RDFLibGraph()
-  this.$shapes = new RDFLibGraph()
-  this.depth = 0
-  this.results = null
-  this.validationEngine = null
-  this.validationError = null
-  this.sequence = null
-  this.shapesGraph = new ShapesGraph(this)
-  this.configuration = new ValidationEngineConfiguration()
-  this.functionsRegistry = require('./src/libraries')
-}
-
-SHACLValidator.prototype.compareNodes = function (node1, node2) {
-  // TODO: Does not handle the case where nodes cannot be compared
-  if (node1 && node1.termType === 'Literal' && node2 && node2.termType === 'Literal') {
-    if ((node1.datatype != null) !== (node2.datatype != null)) {
-      return null
-    } else if (node1.datatype && node2.datatype && node1.datatype.value !== node2.datatype.value) {
-      return null
-    }
-  }
-  return RDFQuery.compareTerms(node1, node2)
-}
-
-SHACLValidator.prototype.getConfiguration = function () {
-  return this.configuration
-}
-
-SHACLValidator.prototype.nodeConformsToShape = function (focusNode, shapeNode) {
-  var shape = this.shapesGraph.getShape(shapeNode)
-  try {
-    this.depth++
-    var foundViolations = this.validationEngine.validateNodeAgainstShape(focusNode, shape, this.$data)
-    return !foundViolations
-  } finally {
-    this.depth--
-  }
-}
-
-// Data graph and Shapes graph logic
-
-/**
- * Reloads the shapes graph.
- * It will load SHACL and DASH shapes constraints.
- */
-SHACLValidator.prototype.loadDataGraph = function (graph) {
-  this.$data.clear()
-  this.$data.loadGraph(dataGraphURI, graph)
-}
-
-/**
- * Validates the data graph against the shapes graph using the validation engine
- */
-SHACLValidator.prototype.updateValidationEngine = function () {
-  this.validationEngine = new ValidationEngine(this)
-  this.validationEngine.setConfiguration(this.configuration)
-  try {
+class SHACLValidator {
+  constructor () {
+    this.$data = new RDFLibGraph()
+    this.$shapes = new RDFLibGraph()
+    this.depth = 0
+    this.results = null
+    this.validationEngine = null
     this.validationError = null
-    if (this.sequence) {
-      this.sequence = []
-    }
-    this.validationEngine.validateAll(this.$data)
-  } catch (ex) {
-    this.validationError = ex
+    this.sequence = null
+    this.shapesGraph = new ShapesGraph(this)
+    this.configuration = new ValidationEngineConfiguration()
+    this.functionsRegistry = require('./src/libraries')
   }
-}
 
-/**
- * Checks for a validation error or results in the validation
- * engine to build the RDF graph with the validation report.
- * It returns a ValidationReport object wrapping the RDF graph
- */
-SHACLValidator.prototype.showValidationResults = async function () {
-  if (this.validationError) {
-    error('Validation Failure: ' + this.validationError)
-    throw (this.validationError)
-  } else {
-    var resultGraph = rdf.dataset()
-    var reportNode = TermFactory.blankNode('report')
-    resultGraph.add(rdf.quad(reportNode, T('rdf:type'), T('sh:ValidationReport')))
-    resultGraph.add(rdf.quad(reportNode, T('sh:conforms'), T('' + (this.validationEngine.results.length === 0))))
-    var nodes = {}
-
-    for (var i = 0; i < this.validationEngine.results.length; i++) {
-      var result = this.validationEngine.results[i]
-      if (nodes[result[0].toString()] == null) {
-        nodes[result[0].toString()] = true
-        resultGraph.add(rdf.quad(reportNode, T('sh:result'), result[0]))
-      }
-      resultGraph.add(rdf.quad(result[0], result[1], result[2]))
-    }
-
-    // Unsupported bug in JSON parser bug workaround
-    var oldToString = resultGraph.toString
-    resultGraph.toString = function () {
-      var text = oldToString.call(resultGraph)
-      text = text.replace(/^\{/, '').replace(/\}$/, '')
-      return text
-    }
-    /// ///////////////
-
-    return jsonld.fromRDF(resultGraph.toString())
-      .then((doc) => jsonld.flatten(doc))
-      .then((flatDoc) => new ValidationReport(flatDoc))
-  }
-}
-
-/**
- * Reloads the shapes graph.
- * It will load SHACL and DASH shapes constraints.
- */
-SHACLValidator.prototype.loadShapesGraph = async function (graph) {
-  this.$shapes.clear()
-
-  this.$shapes.loadGraph(shapesGraphURI, graph)
-
-  this.$shapes.loadGraph('http://shacl.org', this.loadVocabulary('shacl'))
-  this.$shapes.loadGraph('http://datashapes.org/dash', this.loadVocabulary('dash'))
-}
-
-SHACLValidator.prototype.loadVocabulary = function (vocab) {
-  const vocabFactory = require(`./src/vocabularies/${vocab}`)
-  const quads = vocabFactory(rdf)
-  return rdf.dataset(quads)
-}
-
-// Update validations
-
-/**
- * Updates the data graph and validate it against the current data shapes
- */
-SHACLValidator.prototype.updateDataGraph = async function (graph) {
-  var startTime = new Date().getTime()
-  await this.loadDataGraph(graph)
-
-  var midTime = new Date().getTime()
-  this.updateValidationEngine()
-
-  var endTime = new Date().getTime()
-  debug('Parsing took ' + (midTime - startTime) + ' ms. Validating the data took ' + (endTime - midTime) + ' ms.')
-
-  return this.showValidationResults()
-}
-
-/**
- *  Updates the shapes graph from a memory model, and validates it against the current data graph
- */
-SHACLValidator.prototype.updateShapesGraph = async function (graph) {
-  var startTime = new Date().getTime()
-  await this.loadShapesGraph(graph)
-
-  var midTime = new Date().getTime()
-  this.shapesGraph = new ShapesGraph(this)
-  var midTime2 = new Date().getTime()
-
-  await this.shapesGraph.loadJSLibraries()
-  this.updateValidationEngine()
-
-  var endTime = new Date().getTime()
-  debug('Parsing took ' + (midTime - startTime) + ' ms. Preparing the shapes took ' + (midTime2 - midTime) +
-        ' ms. Validation the data took ' + (endTime - midTime2) + ' ms.')
-
-  return this.showValidationResults()
-}
-
-/**
-* Validates the provided data graph against the provided shapes graph
-*/
-SHACLValidator.prototype.validate = async function (dataGraph, shapesGraph) {
-  await this.updateDataGraph(dataGraph)
-  return this.updateShapesGraph(shapesGraph)
-}
-
-/**
- * Saves a cached version of a remote JS file used during validation
- * @param url URL of the library to cache
- * @param localFile path to a local version of the file identified by url
- */
-SHACLValidator.prototype.registerJSLibrary = async function (url, localFile) {
-  const buffer = await readFile(localFile)
-  this.functionsRegistry[url] = buffer.toString()
-}
-
-/**
- * Saves a some JS library code using the provided URL that can be used during validation
- * @param url URL of the library to register
- * @param libraryCode JS code for the library being registered
+  /**
+  * Validates the provided data graph against the provided shapes graph
   */
-SHACLValidator.prototype.registerJSCode = function (url, jsCode) {
-  this.functionsRegistry[url] = jsCode
+  async validate (dataGraph, shapesGraph) {
+    await this.updateDataGraph(dataGraph)
+    return this.updateShapesGraph(shapesGraph)
+  }
+
+  /**
+   * Saves a cached version of a remote JS file used during validation
+   *
+   * @param url URL of the library to cache
+   * @param localFile path to a local version of the file identified by url
+   */
+  async registerJSLibrary (url, localFile) {
+    const buffer = await readFile(localFile)
+    this.functionsRegistry[url] = buffer.toString()
+  }
+
+  /**
+   * Saves a some JS library code using the provided URL that can be used during validation
+   *
+   * @param url URL of the library to register
+   * @param libraryCode JS code for the library being registered
+    */
+  registerJSCode (url, jsCode) {
+    this.functionsRegistry[url] = jsCode
+  }
+
+  getConfiguration () {
+    return this.configuration
+  }
+
+  // Exposed to be available from validation functions as `SHACL.compareNodes`
+  compareNodes (node1, node2) {
+    // TODO: Does not handle the case where nodes cannot be compared
+    if (node1 && node1.termType === 'Literal' && node2 && node2.termType === 'Literal') {
+      if ((node1.datatype != null) !== (node2.datatype != null)) {
+        return null
+      } else if (node1.datatype && node2.datatype && node1.datatype.value !== node2.datatype.value) {
+        return null
+      }
+    }
+    return RDFQuery.compareTerms(node1, node2)
+  }
+
+  // Exposed to be available from validation functions as `SHACL.nodeConformsToShape`
+  nodeConformsToShape (focusNode, shapeNode) {
+    var shape = this.shapesGraph.getShape(shapeNode)
+    try {
+      this.depth++
+      var foundViolations = this.validationEngine.validateNodeAgainstShape(focusNode, shape, this.$data)
+      return !foundViolations
+    } finally {
+      this.depth--
+    }
+  }
+
+  /**
+   * Reloads the shapes graph.
+   * It will load SHACL and DASH shapes constraints.
+   */
+  loadDataGraph (graph) {
+    this.$data.clear()
+    this.$data.loadGraph(dataGraphURI, graph)
+  }
+
+  /**
+   * Validates the data graph against the shapes graph using the validation engine
+   */
+  updateValidationEngine () {
+    this.validationEngine = new ValidationEngine(this)
+    this.validationEngine.setConfiguration(this.configuration)
+    try {
+      this.validationError = null
+      if (this.sequence) {
+        this.sequence = []
+      }
+      this.validationEngine.validateAll(this.$data)
+    } catch (ex) {
+      this.validationError = ex
+    }
+  }
+
+  /**
+   * Checks for a validation error or results in the validation
+   * engine to build the RDF graph with the validation report.
+   * It returns a ValidationReport object wrapping the RDF graph
+   */
+  async showValidationResults () {
+    if (this.validationError) {
+      error('Validation Failure: ' + this.validationError)
+      throw (this.validationError)
+    } else {
+      var resultGraph = rdf.dataset()
+      var reportNode = TermFactory.blankNode('report')
+      resultGraph.add(rdf.quad(reportNode, T('rdf:type'), T('sh:ValidationReport')))
+      resultGraph.add(rdf.quad(reportNode, T('sh:conforms'), T('' + (this.validationEngine.results.length === 0))))
+      var nodes = {}
+
+      for (var i = 0; i < this.validationEngine.results.length; i++) {
+        var result = this.validationEngine.results[i]
+        if (nodes[result[0].toString()] == null) {
+          nodes[result[0].toString()] = true
+          resultGraph.add(rdf.quad(reportNode, T('sh:result'), result[0]))
+        }
+        resultGraph.add(rdf.quad(result[0], result[1], result[2]))
+      }
+
+      // Unsupported bug in JSON parser bug workaround
+      var oldToString = resultGraph.toString
+      resultGraph.toString = function () {
+        var text = oldToString.call(resultGraph)
+        text = text.replace(/^\{/, '').replace(/\}$/, '')
+        return text
+      }
+      /// ///////////////
+
+      return jsonld.fromRDF(resultGraph.toString())
+        .then((doc) => jsonld.flatten(doc))
+        .then((flatDoc) => new ValidationReport(flatDoc))
+    }
+  }
+
+  /**
+   * Reloads the shapes graph.
+   * It will load SHACL and DASH shapes constraints.
+   */
+  async loadShapesGraph (graph) {
+    this.$shapes.clear()
+
+    this.$shapes.loadGraph(shapesGraphURI, graph)
+
+    this.$shapes.loadGraph('http://shacl.org', loadVocabulary('shacl'))
+    this.$shapes.loadGraph('http://datashapes.org/dash', loadVocabulary('dash'))
+  }
+
+  /**
+   * Updates the data graph and validate it against the current data shapes
+   */
+  async updateDataGraph (graph) {
+    var startTime = new Date().getTime()
+    await this.loadDataGraph(graph)
+
+    var midTime = new Date().getTime()
+    this.updateValidationEngine()
+
+    var endTime = new Date().getTime()
+    debug('Parsing took ' + (midTime - startTime) + ' ms. Validating the data took ' + (endTime - midTime) + ' ms.')
+
+    return this.showValidationResults()
+  }
+
+  /**
+   *  Updates the shapes graph from a memory model, and validates it against the current data graph
+   */
+  async updateShapesGraph (graph) {
+    var startTime = new Date().getTime()
+    await this.loadShapesGraph(graph)
+
+    var midTime = new Date().getTime()
+    this.shapesGraph = new ShapesGraph(this)
+    var midTime2 = new Date().getTime()
+
+    await this.shapesGraph.loadJSLibraries()
+    this.updateValidationEngine()
+
+    var endTime = new Date().getTime()
+    debug('Parsing took ' + (midTime - startTime) + ' ms. Preparing the shapes took ' + (midTime2 - midTime) +
+          ' ms. Validation the data took ' + (endTime - midTime2) + ' ms.')
+
+    return this.showValidationResults()
+  }
 }
 
 // Expose the RDF interface
 // TODO: Check $rdf was exposed on the validator. Do we need that?
 // SHACLValidator.$rdf = $rdf;
+
+function loadVocabulary (vocab) {
+  const vocabFactory = require(`./src/vocabularies/${vocab}`)
+  const quads = vocabFactory(rdf)
+  return rdf.dataset(quads)
+}
 
 module.exports = SHACLValidator

--- a/src/rdflib-graph.js
+++ b/src/rdflib-graph.js
@@ -6,48 +6,53 @@ var TermFactory = require('./rdfquery/term-factory')
 /**
  * Creates a new RDFLibGraph wrapping a provided `Dataset` or creating
  * a new one if no dataset is provided
+ *
  * @param store rdfjs Dataset object
  * @constructor
  */
-var RDFLibGraph = function (store) {
-  if (store != null) {
-    this.store = store
-  } else {
+class RDFLibGraph {
+  constructor (store) {
+    if (store != null) {
+      this.store = store
+    } else {
+      this.store = rdf.dataset()
+    }
+  }
+
+  find (s, p, o) {
+    return new RDFLibGraphIterator(this.store, s, p, o)
+  }
+
+  query () {
+    return RDFQuery(this)
+  }
+
+  loadGraph (graphURI, rdfModel) {
+    postProcessGraph(this.store, graphURI, rdfModel)
+  }
+
+  clear () {
     this.store = rdf.dataset()
   }
 }
 
-RDFLibGraph.prototype.find = function (s, p, o) {
-  return new RDFLibGraphIterator(this.store, s, p, o)
-}
+class RDFLibGraphIterator {
+  constructor (store, s, p, o) {
+    this.index = 0
+    // TODO: Could probably make a lazy iterator since Dataset is already an iterator
+    this.ss = store.match(s, p, o).toArray()
+  }
 
-RDFLibGraph.prototype.query = function () {
-  return RDFQuery(this)
-}
+  close () {
+    // Do nothing
+  }
 
-RDFLibGraph.prototype.loadGraph = function (graphURI, rdfModel) {
-  postProcessGraph(this.store, graphURI, rdfModel)
-}
-
-RDFLibGraph.prototype.clear = function () {
-  this.store = rdf.dataset()
-}
-
-var RDFLibGraphIterator = function (store, s, p, o) {
-  this.index = 0
-  // TODO: Could probably make a lazy iterator since Dataset is already an iterator
-  this.ss = store.match(s, p, o).toArray()
-}
-
-RDFLibGraphIterator.prototype.close = function () {
-  // Do nothing
-}
-
-RDFLibGraphIterator.prototype.next = function () {
-  if (this.index >= this.ss.length) {
-    return null
-  } else {
-    return this.ss[this.index++]
+  next () {
+    if (this.index >= this.ss.length) {
+      return null
+    } else {
+      return this.ss[this.index++]
+    }
   }
 }
 

--- a/src/validation-engine-configuration.js
+++ b/src/validation-engine-configuration.js
@@ -1,16 +1,18 @@
 
-var ValidationEngineConfiguration = function () {
-  // By default validate all errors
-  this.validationErrorBatch = -1
-}
+class ValidationEngineConfiguration {
+  constructor () {
+    // By default validate all errors
+    this.validationErrorBatch = -1
+  }
 
-ValidationEngineConfiguration.prototype.setValidationErrorBatch = function (validationErrorBatch) {
-  this.validationErrorBatch = validationErrorBatch
-  return this
-}
+  setValidationErrorBatch (validationErrorBatch) {
+    this.validationErrorBatch = validationErrorBatch
+    return this
+  }
 
-ValidationEngineConfiguration.prototype.getValidationErrorBatch = function () {
-  return this.validationErrorBatch
+  getValidationErrorBatch () {
+    return this.validationErrorBatch
+  }
 }
 
 module.exports = ValidationEngineConfiguration

--- a/src/validation-engine.js
+++ b/src/validation-engine.js
@@ -3,7 +3,301 @@ var T = RDFQuery.T
 var TermFactory = require('./rdfquery/term-factory')
 var ValidationEngineConfiguration = require('./validation-engine-configuration')
 
-var nodeLabel = function (node, store) {
+class ValidationEngine {
+  constructor (context, conformanceOnly) {
+    this.context = context
+    this.conformanceOnly = conformanceOnly
+    this.results = []
+    this.recordErrorsLevel = 0
+    this.violationsCount = 0
+    this.setConfiguration(new ValidationEngineConfiguration())
+  }
+
+  addResultProperty (result, predicate, object) {
+    this.results.push([result, predicate, object])
+  }
+
+  /**
+   * Creates a new BlankNode holding the SHACL validation result, adding the default
+   * properties for the constraint, focused node and value node
+   */
+  createResult (constraint, focusNode, valueNode) {
+    var result = TermFactory.blankNode()
+    var severity = constraint.shape.severity
+    var sourceConstraintComponent = constraint.component.node
+    var sourceShape = constraint.shape.shapeNode
+    this.addResultProperty(result, T('rdf:type'), T('sh:ValidationResult'))
+    this.addResultProperty(result, T('sh:resultSeverity'), severity)
+    this.addResultProperty(result, T('sh:sourceConstraintComponent'), sourceConstraintComponent)
+    this.addResultProperty(result, T('sh:sourceShape'), sourceShape)
+    this.addResultProperty(result, T('sh:focusNode'), focusNode)
+    if (valueNode) {
+      this.addResultProperty(result, T('sh:value'), valueNode)
+    }
+    return result
+  }
+
+  /**
+   * Creates all the validation result nodes and messages for the result of applying the validation logic
+   * of a constraints against a node.
+   * Result passed as the first argument can be false, a resultMessage or a validation result object.
+   * If none of these values is passed no error result or error message will be created.
+   */
+  createResultFromObject (obj, constraint, focusNode, valueNode) {
+    if (obj === false) {
+      if (this.recordErrorsLevel > 0) {
+        if (this.conformanceOnly) {
+          return false
+        } else {
+          return true
+        }
+      }
+
+      if (this.conformanceOnly) {
+        return false
+      }
+      var result = this.createResult(constraint, focusNode, valueNode)
+      if (constraint.shape.isPropertyShape()) {
+        this.addResultProperty(result, T('sh:resultPath'), constraint.shape.path) // TODO: Make deep copy
+      }
+      this.createResultMessages(result, constraint)
+      return true
+    } else if (typeof obj === 'string') {
+      if (this.recordErrorsLevel > 0) {
+        if (this.conformanceOnly) {
+          return false
+        } else {
+          return true
+        }
+      }
+      if (this.conformanceOnly) {
+        return false
+      }
+      result = this.createResult(constraint, focusNode, valueNode)
+      if (constraint.shape.isPropertyShape()) {
+        this.addResultProperty(result, T('sh:resultPath'), constraint.shape.path) // TODO: Make deep copy
+      }
+      this.addResultProperty(result, T('sh:resultMessage'), TermFactory.literal(obj, T('xsd:string')))
+      this.createResultMessages(result, constraint)
+      return true
+    } else if (typeof obj === 'object') {
+      if (this.recordErrorsLevel > 0) {
+        if (this.conformanceOnly) {
+          return false
+        } else {
+          return true
+        }
+      }
+      if (this.conformanceOnly) {
+        return false
+      }
+      result = this.createResult(constraint, focusNode)
+      if (obj.path) {
+        this.addResultProperty(result, T('sh:resultPath'), obj.path) // TODO: Make deep copy
+      } else if (constraint.shape.isPropertyShape()) {
+        this.addResultProperty(result, T('sh:resultPath'), constraint.shape.path) // TODO: Make deep copy
+      }
+      if (obj.value) {
+        this.addResultProperty(result, T('sh:value'), obj.value)
+      } else if (valueNode) {
+        this.addResultProperty(result, T('sh:value'), valueNode)
+      }
+      if (obj.message) {
+        this.addResultProperty(result, T('sh:resultMessage'), TermFactory.literal(obj.message, T('xsd:string')))
+      } else {
+        this.createResultMessages(result, constraint)
+      }
+      return true
+    }
+    return false
+  }
+
+  /**
+   * Creates a result message from the result and the message pattern in the constraint
+   */
+  createResultMessages (result, constraint) {
+    var ms = this.context.$shapes.query()
+      .match(constraint.shape.shapeNode, 'sh:message', '?message')
+      .getNodeArray('?message')
+    if (ms.length === 0) {
+      var generic = constraint.shape.isPropertyShape()
+        ? constraint.component.propertyValidationFunctionGeneric
+        : constraint.component.nodeValidationFunctionGeneric
+      var predicate = generic ? T('sh:validator') : (constraint.shape.isPropertyShape() ? T('sh:propertyValidator') : T('sh:nodeValidator'))
+      ms = this.context.$shapes.query()
+        .match(constraint.component.node, predicate, '?validator')
+        .match('?validator', 'sh:message', '?message')
+        .getNodeArray('?message')
+    }
+    if (ms.length === 0) {
+      ms = this.context.$shapes.query()
+        .match(constraint.component.node, 'sh:message', '?message')
+        .getNodeArray('?message')
+    }
+    for (var i = 0; i < ms.length; i++) {
+      var m = ms[i]
+      var str = this.withSubstitutions(m, constraint)
+      this.addResultProperty(result, T('sh:resultMessage'), str)
+    }
+  }
+
+  /**
+   * Validates the data graph against the shapes graph
+   */
+  validateAll (rdfDataGraph) {
+    if (this.maxErrorsReached()) {
+      return true
+    } else {
+      this.results = []
+      var foundError = false
+      var shapes = this.context.shapesGraph.getShapesWithTarget()
+      for (var i = 0; i < shapes.length; i++) {
+        var shape = shapes[i]
+        var focusNodes = shape.getTargetNodes(rdfDataGraph)
+        for (var j = 0; j < focusNodes.length; j++) {
+          if (this.validateNodeAgainstShape(focusNodes[j], shape, rdfDataGraph)) {
+            foundError = true
+          }
+        }
+      }
+      return foundError
+    }
+  }
+
+  /**
+   * Returns true if any violation has been found
+   */
+  validateNodeAgainstShape (focusNode, shape, rdfDataGraph) {
+    if (this.maxErrorsReached()) {
+      return true
+    } else {
+      if (shape.deactivated) {
+        return false
+      }
+      var constraints = shape.getConstraints()
+      var valueNodes = shape.getValueNodes(focusNode, rdfDataGraph)
+      var errorFound = false
+      for (var i = 0; i < constraints.length; i++) {
+        if (this.validateNodeAgainstConstraint(focusNode, valueNodes, constraints[i], rdfDataGraph)) {
+          errorFound = true
+        }
+      }
+      return errorFound
+    }
+  }
+
+  validateNodeAgainstConstraint (focusNode, valueNodes, constraint, rdfDataGraph) {
+    if (this.maxErrorsReached()) {
+      return true
+    } else {
+      if (T('sh:PropertyConstraintComponent').equals(constraint.component.node)) {
+        let errorFound = false
+        for (var i = 0; i < valueNodes.length; i++) {
+          if (this.validateNodeAgainstShape(valueNodes[i], this.context.shapesGraph.getShape(constraint.paramValue), rdfDataGraph)) {
+            errorFound = true
+          }
+        }
+        return errorFound
+      } else {
+        const validationFunction = constraint.shape.isPropertyShape()
+          ? constraint.component.propertyValidationFunction
+          : constraint.component.nodeValidationFunction
+        if (validationFunction) {
+          const generic = constraint.shape.isPropertyShape()
+            ? constraint.component.propertyValidationFunctionGeneric
+            : constraint.component.nodeValidationFunctionGeneric
+          if (generic) {
+            // Generic sh:validator is called for each value node separately
+            let errorFound = false
+            for (i = 0; i < valueNodes.length; i++) {
+              if (this.maxErrorsReached()) {
+                break
+              }
+              let iterationError = false
+              const valueNode = valueNodes[i]
+              // if (validationFunction.funcName === "validateAnd" || validationFunction.funcName === "validateOr" || validationFunction.funcName === "validateNot") {
+              this.recordErrorsLevel++
+              // }
+              const obj = validationFunction.execute(focusNode, valueNode, constraint)
+              // if (validationFunction.funcName === "validateAnd" || validationFunction.funcName === "validateOr" || validationFunction.funcName === "validateNot") {
+              this.recordErrorsLevel--
+              // }
+              if (Array.isArray(obj)) {
+                for (let a = 0; a < obj.length; a++) {
+                  if (this.createResultFromObject(obj[a], constraint, focusNode, valueNode)) {
+                    iterationError = true
+                  }
+                }
+              } else {
+                if (this.createResultFromObject(obj, constraint, focusNode, valueNode)) {
+                  iterationError = true
+                }
+              }
+              if (iterationError) {
+                this.violationsCount++
+              }
+              errorFound = errorFound || iterationError
+            }
+            return errorFound
+          } else {
+            // if (validationFunction.funcName === "validateAnd" || validationFunction.funcName === "validateOr" || validationFunction.funcName === "validateNot") {
+            this.recordErrorsLevel++
+            // }
+            const obj = validationFunction.execute(focusNode, null, constraint)
+            // if (validationFunction.funcName === "validateAnd" || validationFunction.funcName === "validateOr" || validationFunction.funcName === "validateNot") {
+            this.recordErrorsLevel--
+            // }
+            if (Array.isArray(obj)) {
+              let errorFound = false
+              for (let a = 0; a < obj.length; a++) {
+                if (this.createResultFromObject(obj[a], constraint, focusNode)) {
+                  errorFound = true
+                }
+              }
+              return errorFound
+            } else {
+              if (this.createResultFromObject(obj, constraint, focusNode)) {
+                return true
+              }
+            }
+          }
+        } else {
+          throw new Error('Cannot find validator for constraint component ' + constraint.component.node.value)
+        }
+      }
+      return false
+    }
+  }
+
+  maxErrorsReached () {
+    if (this.getConfiguration().getValidationErrorBatch() === -1) {
+      return false
+    } else {
+      return this.violationsCount >= this.getConfiguration().getValidationErrorBatch()
+    }
+  }
+
+  withSubstitutions (msg, constraint) {
+    var str = msg.value
+    var values = constraint.parameterValues
+    for (const key in values) {
+      var label = nodeLabel(values[key], this.context.$shapes)
+      str = str.replace('{$' + key + '}', label)
+      str = str.replace('{?' + key + '}', label)
+    }
+    return TermFactory.literal(str, msg.language | msg.datatype)
+  }
+
+  getConfiguration () {
+    return this.configuration
+  }
+
+  setConfiguration (configuration) {
+    this.configuration = configuration
+  }
+}
+
+function nodeLabel (node, store) {
   if (node.termType === 'Collection') {
     var acc = []
     for (var i = 0; i < node.elements.length; i++) {
@@ -24,300 +318,6 @@ var nodeLabel = function (node, store) {
   } else {
     return '' + node.value
   }
-}
-
-// class ValidationEngine
-
-var ValidationEngine = function (context, conformanceOnly) {
-  this.context = context
-  this.conformanceOnly = conformanceOnly
-  this.results = []
-  this.recordErrorsLevel = 0
-  this.violationsCount = 0
-  this.setConfiguration(new ValidationEngineConfiguration())
-}
-
-ValidationEngine.prototype.addResultProperty = function (result, predicate, object) {
-  this.results.push([result, predicate, object])
-}
-
-/**
- * Creates a new BlankNode holding the SHACL validation result, adding the default
- * properties for the constraint, focused node and value node
- */
-ValidationEngine.prototype.createResult = function (constraint, focusNode, valueNode) {
-  var result = TermFactory.blankNode()
-  var severity = constraint.shape.severity
-  var sourceConstraintComponent = constraint.component.node
-  var sourceShape = constraint.shape.shapeNode
-  this.addResultProperty(result, T('rdf:type'), T('sh:ValidationResult'))
-  this.addResultProperty(result, T('sh:resultSeverity'), severity)
-  this.addResultProperty(result, T('sh:sourceConstraintComponent'), sourceConstraintComponent)
-  this.addResultProperty(result, T('sh:sourceShape'), sourceShape)
-  this.addResultProperty(result, T('sh:focusNode'), focusNode)
-  if (valueNode) {
-    this.addResultProperty(result, T('sh:value'), valueNode)
-  }
-  return result
-}
-
-/**
- * Creates all the validation result nodes and messages for the result of applying the validation logic
- * of a constraints against a node.
- * Result passed as the first argument can be false, a resultMessage or a validation result object.
- * If none of these values is passed no error result or error message will be created.
- */
-ValidationEngine.prototype.createResultFromObject = function (obj, constraint, focusNode, valueNode) {
-  if (obj === false) {
-    if (this.recordErrorsLevel > 0) {
-      if (this.conformanceOnly) {
-        return false
-      } else {
-        return true
-      }
-    }
-
-    if (this.conformanceOnly) {
-      return false
-    }
-    var result = this.createResult(constraint, focusNode, valueNode)
-    if (constraint.shape.isPropertyShape()) {
-      this.addResultProperty(result, T('sh:resultPath'), constraint.shape.path) // TODO: Make deep copy
-    }
-    this.createResultMessages(result, constraint)
-    return true
-  } else if (typeof obj === 'string') {
-    if (this.recordErrorsLevel > 0) {
-      if (this.conformanceOnly) {
-        return false
-      } else {
-        return true
-      }
-    }
-    if (this.conformanceOnly) {
-      return false
-    }
-    result = this.createResult(constraint, focusNode, valueNode)
-    if (constraint.shape.isPropertyShape()) {
-      this.addResultProperty(result, T('sh:resultPath'), constraint.shape.path) // TODO: Make deep copy
-    }
-    this.addResultProperty(result, T('sh:resultMessage'), TermFactory.literal(obj, T('xsd:string')))
-    this.createResultMessages(result, constraint)
-    return true
-  } else if (typeof obj === 'object') {
-    if (this.recordErrorsLevel > 0) {
-      if (this.conformanceOnly) {
-        return false
-      } else {
-        return true
-      }
-    }
-    if (this.conformanceOnly) {
-      return false
-    }
-    result = this.createResult(constraint, focusNode)
-    if (obj.path) {
-      this.addResultProperty(result, T('sh:resultPath'), obj.path) // TODO: Make deep copy
-    } else if (constraint.shape.isPropertyShape()) {
-      this.addResultProperty(result, T('sh:resultPath'), constraint.shape.path) // TODO: Make deep copy
-    }
-    if (obj.value) {
-      this.addResultProperty(result, T('sh:value'), obj.value)
-    } else if (valueNode) {
-      this.addResultProperty(result, T('sh:value'), valueNode)
-    }
-    if (obj.message) {
-      this.addResultProperty(result, T('sh:resultMessage'), TermFactory.literal(obj.message, T('xsd:string')))
-    } else {
-      this.createResultMessages(result, constraint)
-    }
-    return true
-  }
-  return false
-}
-
-/**
- * Creates a result message from the result and the message pattern in the constraint
- */
-ValidationEngine.prototype.createResultMessages = function (result, constraint) {
-  var ms = this.context.$shapes.query()
-    .match(constraint.shape.shapeNode, 'sh:message', '?message')
-    .getNodeArray('?message')
-  if (ms.length === 0) {
-    var generic = constraint.shape.isPropertyShape()
-      ? constraint.component.propertyValidationFunctionGeneric
-      : constraint.component.nodeValidationFunctionGeneric
-    var predicate = generic ? T('sh:validator') : (constraint.shape.isPropertyShape() ? T('sh:propertyValidator') : T('sh:nodeValidator'))
-    ms = this.context.$shapes.query()
-      .match(constraint.component.node, predicate, '?validator')
-      .match('?validator', 'sh:message', '?message')
-      .getNodeArray('?message')
-  }
-  if (ms.length === 0) {
-    ms = this.context.$shapes.query()
-      .match(constraint.component.node, 'sh:message', '?message')
-      .getNodeArray('?message')
-  }
-  for (var i = 0; i < ms.length; i++) {
-    var m = ms[i]
-    var str = this.withSubstitutions(m, constraint)
-    this.addResultProperty(result, T('sh:resultMessage'), str)
-  }
-}
-
-/**
- * Validates the data graph against the shapes graph
- */
-ValidationEngine.prototype.validateAll = function (rdfDataGraph) {
-  if (this.maxErrorsReached()) {
-    return true
-  } else {
-    this.results = []
-    var foundError = false
-    var shapes = this.context.shapesGraph.getShapesWithTarget()
-    for (var i = 0; i < shapes.length; i++) {
-      var shape = shapes[i]
-      var focusNodes = shape.getTargetNodes(rdfDataGraph)
-      for (var j = 0; j < focusNodes.length; j++) {
-        if (this.validateNodeAgainstShape(focusNodes[j], shape, rdfDataGraph)) {
-          foundError = true
-        }
-      }
-    }
-    return foundError
-  }
-}
-
-/**
- * Returns true if any violation has been found
- */
-ValidationEngine.prototype.validateNodeAgainstShape = function (focusNode, shape, rdfDataGraph) {
-  if (this.maxErrorsReached()) {
-    return true
-  } else {
-    if (shape.deactivated) {
-      return false
-    }
-    var constraints = shape.getConstraints()
-    var valueNodes = shape.getValueNodes(focusNode, rdfDataGraph)
-    var errorFound = false
-    for (var i = 0; i < constraints.length; i++) {
-      if (this.validateNodeAgainstConstraint(focusNode, valueNodes, constraints[i], rdfDataGraph)) {
-        errorFound = true
-      }
-    }
-    return errorFound
-  }
-}
-
-ValidationEngine.prototype.validateNodeAgainstConstraint = function (focusNode, valueNodes, constraint, rdfDataGraph) {
-  if (this.maxErrorsReached()) {
-    return true
-  } else {
-    if (T('sh:PropertyConstraintComponent').equals(constraint.component.node)) {
-      let errorFound = false
-      for (var i = 0; i < valueNodes.length; i++) {
-        if (this.validateNodeAgainstShape(valueNodes[i], this.context.shapesGraph.getShape(constraint.paramValue), rdfDataGraph)) {
-          errorFound = true
-        }
-      }
-      return errorFound
-    } else {
-      const validationFunction = constraint.shape.isPropertyShape()
-        ? constraint.component.propertyValidationFunction
-        : constraint.component.nodeValidationFunction
-      if (validationFunction) {
-        const generic = constraint.shape.isPropertyShape()
-          ? constraint.component.propertyValidationFunctionGeneric
-          : constraint.component.nodeValidationFunctionGeneric
-        if (generic) {
-          // Generic sh:validator is called for each value node separately
-          let errorFound = false
-          for (i = 0; i < valueNodes.length; i++) {
-            if (this.maxErrorsReached()) {
-              break
-            }
-            let iterationError = false
-            const valueNode = valueNodes[i]
-            // if (validationFunction.funcName === "validateAnd" || validationFunction.funcName === "validateOr" || validationFunction.funcName === "validateNot") {
-            this.recordErrorsLevel++
-            // }
-            const obj = validationFunction.execute(focusNode, valueNode, constraint)
-            // if (validationFunction.funcName === "validateAnd" || validationFunction.funcName === "validateOr" || validationFunction.funcName === "validateNot") {
-            this.recordErrorsLevel--
-            // }
-            if (Array.isArray(obj)) {
-              for (let a = 0; a < obj.length; a++) {
-                if (this.createResultFromObject(obj[a], constraint, focusNode, valueNode)) {
-                  iterationError = true
-                }
-              }
-            } else {
-              if (this.createResultFromObject(obj, constraint, focusNode, valueNode)) {
-                iterationError = true
-              }
-            }
-            if (iterationError) {
-              this.violationsCount++
-            }
-            errorFound = errorFound || iterationError
-          }
-          return errorFound
-        } else {
-          // if (validationFunction.funcName === "validateAnd" || validationFunction.funcName === "validateOr" || validationFunction.funcName === "validateNot") {
-          this.recordErrorsLevel++
-          // }
-          const obj = validationFunction.execute(focusNode, null, constraint)
-          // if (validationFunction.funcName === "validateAnd" || validationFunction.funcName === "validateOr" || validationFunction.funcName === "validateNot") {
-          this.recordErrorsLevel--
-          // }
-          if (Array.isArray(obj)) {
-            let errorFound = false
-            for (let a = 0; a < obj.length; a++) {
-              if (this.createResultFromObject(obj[a], constraint, focusNode)) {
-                errorFound = true
-              }
-            }
-            return errorFound
-          } else {
-            if (this.createResultFromObject(obj, constraint, focusNode)) {
-              return true
-            }
-          }
-        }
-      } else {
-        throw new Error('Cannot find validator for constraint component ' + constraint.component.node.value)
-      }
-    }
-    return false
-  }
-}
-
-ValidationEngine.prototype.maxErrorsReached = function () {
-  if (this.getConfiguration().getValidationErrorBatch() === -1) {
-    return false
-  } else {
-    return this.violationsCount >= this.getConfiguration().getValidationErrorBatch()
-  }
-}
-
-ValidationEngine.prototype.withSubstitutions = function (msg, constraint) {
-  var str = msg.value
-  var values = constraint.parameterValues
-  for (const key in values) {
-    var label = nodeLabel(values[key], this.context.$shapes)
-    str = str.replace('{$' + key + '}', label)
-    str = str.replace('{?' + key + '}', label)
-  }
-  return TermFactory.literal(str, msg.language | msg.datatype)
-}
-
-ValidationEngine.prototype.getConfiguration = function () {
-  return this.configuration
-}
-
-ValidationEngine.prototype.setConfiguration = function (configuration) {
-  this.configuration = configuration
 }
 
 module.exports = ValidationEngine

--- a/src/validation-function.js
+++ b/src/validation-function.js
@@ -4,69 +4,71 @@ var debug = require('debug')('validation-function')
 
 var globalObject = typeof window !== 'undefined' ? window : global
 
-var ValidationFunction = function (functionName, parameters, findInScript) {
-  this.funcName = functionName
-  this.func = findInScript(functionName)
-  if (!this.func) {
-    throw new Error('Cannot find validator function ' + functionName)
-  }
-  // Get list of argument of the function, see
-  // https://davidwalsh.name/javascript-arguments
-  var args = this.func.toString().match(/function\s.*?\(([^)]*)\)/)[1]
-  var funcArgsRaw = args.split(',').map(function (arg) {
-    return arg.replace(/\/\*.*\*\//, '').trim()
-  }).filter(function (arg) {
-    return arg
-  })
-  this.funcArgs = []
-  this.parameters = []
-  for (var i = 0; i < funcArgsRaw.length; i++) {
-    var arg = funcArgsRaw[i]
-    if (arg.indexOf('$') === 0) {
-      arg = arg.substring(1)
+class ValidationFunction {
+  constructor (functionName, parameters, findInScript) {
+    this.funcName = functionName
+    this.func = findInScript(functionName)
+    if (!this.func) {
+      throw new Error('Cannot find validator function ' + functionName)
     }
-    this.funcArgs.push(arg)
-    for (var j = 0; j < parameters.length; j++) {
-      var parameter = parameters[j]
-      var localName = RDFQuery.getLocalName(parameter.value)
-      if (arg === localName) {
-        this.parameters[i] = parameter
-        break
+    // Get list of argument of the function, see
+    // https://davidwalsh.name/javascript-arguments
+    var args = this.func.toString().match(/function\s.*?\(([^)]*)\)/)[1]
+    var funcArgsRaw = args.split(',').map(function (arg) {
+      return arg.replace(/\/\*.*\*\//, '').trim()
+    }).filter(function (arg) {
+      return arg
+    })
+    this.funcArgs = []
+    this.parameters = []
+    for (var i = 0; i < funcArgsRaw.length; i++) {
+      var arg = funcArgsRaw[i]
+      if (arg.indexOf('$') === 0) {
+        arg = arg.substring(1)
+      }
+      this.funcArgs.push(arg)
+      for (var j = 0; j < parameters.length; j++) {
+        var parameter = parameters[j]
+        var localName = RDFQuery.getLocalName(parameter.value)
+        if (arg === localName) {
+          this.parameters[i] = parameter
+          break
+        }
       }
     }
   }
-}
 
-ValidationFunction.prototype.doExecute = function (args) {
-  return this.func.apply(globalObject, args)
-}
-
-ValidationFunction.prototype.execute = function (focusNode, valueNode, constraint) {
-  debug('Validating ' + this.funcName)
-  var args = []
-  for (var i = 0; i < this.funcArgs.length; i++) {
-    var arg = this.funcArgs[i]
-    var param = this.parameters[i]
-    if (param) {
-      var value = constraint.getParameterValue(arg)
-      args.push(value)
-    } else if (arg === 'focusNode') {
-      args.push(focusNode)
-    } else if (arg === 'value') {
-      args.push(valueNode)
-    } else if (arg === 'currentShape') {
-      args.push(constraint.shape.shapeNode)
-    } else if (arg === 'path') {
-      args.push(constraint.shape.path)
-    } else if (arg === 'shapesGraph') {
-      args.push('DummyShapesGraph')
-    } else if (arg === 'this') {
-      args.push(focusNode)
-    } else {
-      throw new Error('Unexpected validator function argument ' + arg + ' for function ' + this.funcName)
-    }
+  doExecute (args) {
+    return this.func.apply(globalObject, args)
   }
-  return this.doExecute(args)
+
+  execute (focusNode, valueNode, constraint) {
+    debug('Validating ' + this.funcName)
+    var args = []
+    for (var i = 0; i < this.funcArgs.length; i++) {
+      var arg = this.funcArgs[i]
+      var param = this.parameters[i]
+      if (param) {
+        var value = constraint.getParameterValue(arg)
+        args.push(value)
+      } else if (arg === 'focusNode') {
+        args.push(focusNode)
+      } else if (arg === 'value') {
+        args.push(valueNode)
+      } else if (arg === 'currentShape') {
+        args.push(constraint.shape.shapeNode)
+      } else if (arg === 'path') {
+        args.push(constraint.shape.path)
+      } else if (arg === 'shapesGraph') {
+        args.push('DummyShapesGraph')
+      } else if (arg === 'this') {
+        args.push(focusNode)
+      } else {
+        throw new Error('Unexpected validator function argument ' + arg + ' for function ' + this.funcName)
+      }
+    }
+    return this.doExecute(args)
+  }
 }
 
 module.exports = ValidationFunction

--- a/src/validation-report.js
+++ b/src/validation-report.js
@@ -1,82 +1,97 @@
 
-var extractValue = function (node, property) {
+/**
+ * Result of a SHACL validation.
+ */
+class ValidationReport {
+  constructor (g) {
+    this.graph = g
+    this.validationNode = null
+    for (var i = 0; i < g.length; i++) {
+      var conforms = g[i]['http://www.w3.org/ns/shacl#conforms']
+      if (conforms != null && conforms[0] != null) {
+        this.validationNode = g[i]
+        break
+      }
+    }
+    if (this.validationNode == null) {
+      throw new Error('Cannot find validation report node')
+    }
+  }
+
+  /**
+   * Returns `true` if the data conforms to the defined shapes, `false`
+   * otherwise.
+   */
+  conforms () {
+    var conforms = this.validationNode['http://www.w3.org/ns/shacl#conforms'][0]
+    if (conforms != null) {
+      return conforms['@value'] === 'true'
+    }
+  }
+
+  /**
+   * Returns a list of `ValidationResult` with details about nodes that don't
+   * conform to the given shapes.
+   */
+  results () {
+    var results = this.validationNode['http://www.w3.org/ns/shacl#result'] || []
+    return results.map((result) => new ValidationResult(this.findNode(result['@id']), this.graph))
+  }
+
+  findNode (id) {
+    for (var i = 0; i < this.graph.length; i++) {
+      if (this.graph[i]['@id'] === id) {
+        return this.graph[i]
+      }
+    }
+  }
+}
+
+class ValidationResult {
+  constructor (resultNode, g) {
+    this.graph = g
+    this.resultNode = resultNode
+  }
+
+  message () {
+    return extractValue(this.resultNode, 'http://www.w3.org/ns/shacl#resultMessage')
+  }
+
+  path () {
+    return extractId(this.resultNode, 'http://www.w3.org/ns/shacl#resultPath')
+  }
+
+  focusNode () {
+    return extractId(this.resultNode, 'http://www.w3.org/ns/shacl#focusNode')
+  }
+
+  severity () {
+    var severity = extractId(this.resultNode, 'http://www.w3.org/ns/shacl#resultSeverity')
+    if (severity != null) {
+      return severity.split('#')[1]
+    }
+  }
+
+  sourceConstraintComponent () {
+    return extractId(this.resultNode, 'http://www.w3.org/ns/shacl#sourceConstraintComponent')
+  }
+
+  sourceShape () {
+    return extractId(this.resultNode, 'http://www.w3.org/ns/shacl#sourceShape')
+  }
+}
+
+function extractValue (node, property) {
   var obj = node[property]
   if (obj) {
     return obj[0]['@value']
   }
 }
 
-var extractId = function (node, property) {
+function extractId (node, property) {
   var obj = node[property]
   if (obj) {
     return obj[0]['@id']
-  }
-}
-
-var ValidationResult = function (resultNode, g) {
-  this.graph = g
-  this.resultNode = resultNode
-}
-
-ValidationResult.prototype.message = function () {
-  return extractValue(this.resultNode, 'http://www.w3.org/ns/shacl#resultMessage')
-}
-
-ValidationResult.prototype.path = function () {
-  return extractId(this.resultNode, 'http://www.w3.org/ns/shacl#resultPath')
-}
-
-ValidationResult.prototype.focusNode = function () {
-  return extractId(this.resultNode, 'http://www.w3.org/ns/shacl#focusNode')
-}
-
-ValidationResult.prototype.severity = function () {
-  var severity = extractId(this.resultNode, 'http://www.w3.org/ns/shacl#resultSeverity')
-  if (severity != null) {
-    return severity.split('#')[1]
-  }
-}
-
-ValidationResult.prototype.sourceConstraintComponent = function () {
-  return extractId(this.resultNode, 'http://www.w3.org/ns/shacl#sourceConstraintComponent')
-}
-
-ValidationResult.prototype.sourceShape = function () {
-  return extractId(this.resultNode, 'http://www.w3.org/ns/shacl#sourceShape')
-}
-
-var ValidationReport = function (g) {
-  this.graph = g
-  this.validationNode = null
-  for (var i = 0; i < g.length; i++) {
-    var conforms = g[i]['http://www.w3.org/ns/shacl#conforms']
-    if (conforms != null && conforms[0] != null) {
-      this.validationNode = g[i]
-      break
-    }
-  }
-  if (this.validationNode == null) {
-    throw new Error('Cannot find validation report node')
-  }
-}
-
-ValidationReport.prototype.conforms = function () {
-  var conforms = this.validationNode['http://www.w3.org/ns/shacl#conforms'][0]
-  if (conforms != null) {
-    return conforms['@value'] === 'true'
-  }
-}
-
-ValidationReport.prototype.results = function () {
-  var results = this.validationNode['http://www.w3.org/ns/shacl#result'] || []
-  return results.map((result) => new ValidationResult(this.findNode(result['@id']), this.graph))
-}
-
-ValidationReport.prototype.findNode = function (id) {
-  for (var i = 0; i < this.graph.length; i++) {
-    if (this.graph[i]['@id'] === id) {
-      return this.graph[i]
-    }
   }
 }
 


### PR DESCRIPTION
I couldn't make `shapes_graph.ConstraintComponent` into a class yet because it seems to break the execution context of the part that uses `eval`. Will fix in the future. Hopefully we can get rid of `eval`.

I will probably squash the commits when merging.