### PR TITLE
Redo validation report

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Holger Knublauch <holger@topquadrant.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "jsonld": "2.0.2",
+    "@rdfjs/namespace": "1.1.0",
     "rdf-ext": "1.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "rdf-ext": "1.3.0"
   },
   "devDependencies": {
+    "clownface": "0.12.1",
     "@rdfjs/parser-n3": "1.1.3",
     "@zazuko/rdf-vocabularies": "2020.2.11",
     "debug": "4.1.1",

--- a/src/namespaces.js
+++ b/src/namespaces.js
@@ -1,0 +1,7 @@
+const namespace = require('@rdfjs/namespace')
+
+const sh = namespace('http://www.w3.org/ns/shacl#')
+const xsd = namespace('http://www.w3.org/2001/XMLSchema#')
+const rdf = namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#')
+
+module.exports = { sh, xsd, rdf }

--- a/test/function_registration_tests.js
+++ b/test/function_registration_tests.js
@@ -12,7 +12,8 @@ var results = {
     message: 'Value has more than 3 characters'
   },
   'http://datashapes.org/sh/tests/functionregistry/jsconstraintcomponent/data#InvalidExampleShape': {
-    message: 'Shape is constantly valid false'
+    message: 'Shape is constantly valid false',
+    path: null
   }
 }
 

--- a/test/validation_report_tests.js
+++ b/test/validation_report_tests.js
@@ -1,0 +1,95 @@
+/* eslint-env mocha */
+const assert = require('assert')
+const rdf = require('rdf-ext')
+const clownface = require('clownface')
+
+const { rdf: rdfNS, sh } = require('../src/namespaces')
+const ValidationReport = require('../src/validation-report')
+
+describe('ValidationReport', () => {
+  it('returns a validation report', () => {
+    const report = new ValidationReport([])
+
+    assert.ok(report instanceof ValidationReport)
+  })
+
+  describe('#conforms()', () => {
+    it('conforms', () => {
+      const report = new ValidationReport([])
+
+      assert.ok(report.conforms())
+    })
+
+    it('does not conform', () => {
+      const results = [rdf.quad(rdf.blankNode(), sh.focusNode, rdf.blankNode())]
+
+      const report = new ValidationReport(results)
+      assert.ok(!report.conforms())
+    })
+  })
+
+  describe('#results()', () => {
+    it('returns empty list', () => {
+      const report = new ValidationReport([])
+
+      assert.deepStrictEqual(report.results(), [])
+    })
+
+    it('returns reports list', () => {
+      const results = [
+        rdf.quad(rdf.blankNode(), sh.focusNode, rdf.blankNode()),
+        rdf.quad(rdf.blankNode(), sh.focusNode, rdf.blankNode())
+      ]
+
+      const report = new ValidationReport(results)
+
+      assert.strictEqual(report.results().length, 2)
+    })
+  })
+
+  describe('#dataset', () => {
+    it('returns a dataset with a report that conforms', () => {
+      const report = new ValidationReport([])
+
+      const dataset = report.dataset
+
+      const cf = clownface({ dataset })
+      const cfReport = cf.namedNode(sh.ValidationReport).in(rdfNS.type)
+      const conforms = cfReport.out(sh.conforms).values
+      assert.deepStrictEqual(conforms, [true])
+      const results = cfReport.out(sh.result).values
+      assert.deepStrictEqual(results, [])
+    })
+
+    it('returns a dataset with a report that does not conform', async () => {
+      const resultID1 = rdf.blankNode()
+      const resultID2 = rdf.blankNode()
+      const report = new ValidationReport([
+        rdf.quad(resultID1, sh.resultMessage, 'Something is invalid'),
+        rdf.quad(resultID2, sh.resultMessage, 'Some other thing is invalid'),
+        rdf.quad(resultID1, sh.resultPath, rdf.namedNode('ex:aProperty')),
+        rdf.quad(resultID2, sh.resultPath, rdf.namedNode('ex:aProperty'))
+      ])
+
+      const dataset = report.dataset
+
+      const cf = clownface({ dataset })
+      const cfReport = cf.namedNode(sh.ValidationReport).in(rdfNS.type)
+      const conforms = cfReport.out(sh.conforms).values
+      assert.deepStrictEqual(conforms, [false])
+      const results = cfReport.out(sh.result).map((cfResult) => cfResult.out().values)
+      assert.deepStrictEqual(results, [
+        ['Something is invalid', 'ex:aProperty'],
+        ['Some other thing is invalid', 'ex:aProperty']
+      ])
+    })
+  })
+
+  describe('#term', () => {
+    it('returns the sh:ValidationReport term', () => {
+      const report = new ValidationReport([])
+
+      assert.strictEqual(report.term.termType, 'BlankNode')
+    })
+  })
+})


### PR DESCRIPTION
- Remove `jsonld` dependency
- Add `ValidationReport.dataset`
- Add `ValidationReport.term`

Fixes #2 

I didn't change the current `.conforms()` and `.results()` to be properties instead of functions yet, as I wasn't sure we decided to do it. Will do in a later PR if it's confirmed. (same for `ValidationResult` methods).