### PR TITLE
Remove postprocessing after loading quads

### DIFF
--- a/src/rdflib-graph.js
+++ b/src/rdflib-graph.js
@@ -1,6 +1,5 @@
 const DataFactory = require('./data-factory')
 const RDFQuery = require('./rdfquery')
-const { xsd } = require('./namespaces')
 
 /**
  * Creates a new RDFLibGraph wrapping a provided `DatasetCore` or creating
@@ -27,46 +26,16 @@ class RDFLibGraph {
   }
 
   loadGraph (graphURI, dataset) {
-    this._postProcessGraph(graphURI, dataset)
+    const graph = this.factory.namedNode(graphURI)
+
+    for (const quad of dataset) {
+      const quadWithGraph = this.factory.quad(quad.subject, quad.predicate, quad.object, graph)
+      this.dataset.add(quadWithGraph)
+    }
   }
 
   clear () {
     this.dataset = this.factory.dataset()
-  }
-
-  _postProcessGraph (graphURI, newDataset) {
-    const ss = newDataset.match(undefined, undefined, undefined)
-    for (const quad of ss) {
-      const object = quad.object
-      ensureBlankId(quad.subject)
-      ensureBlankId(quad.predicate)
-      ensureBlankId(quad.object)
-      if (xsd.boolean.equals(object.datatype)) {
-        if (object.value === '0' || object.value === 'false') {
-          this.dataset.add(this.factory.quad(quad.subject, quad.predicate, this.factory.term('false'), graphURI))
-        } else if (object.value === '1' || object.value === 'true') {
-          this.dataset.add(this.factory.quad(quad.subject, quad.predicate, this.factory.term('true'), graphURI))
-        } else {
-          this.dataset.add(this.factory.quad(quad.subject, quad.predicate, object, graphURI))
-        }
-      } else if (object.termType === 'collection') {
-        const items = object.elements
-        this.dataset.add(this.factory.quad(quad.subject, quad.predicate, this._createRDFListNode(items, 0)))
-      } else {
-        this.dataset.add(this.factory.quad(quad.subject, quad.predicate, quad.object, graphURI))
-      }
-    }
-  }
-
-  _createRDFListNode (items, index) {
-    if (index >= items.length) {
-      return this.factory.term('rdf:nil')
-    } else {
-      const bnode = this.factory.blankNode()
-      this.dataset.add(this.factory.quad(bnode, this.factory.term('rdf:first'), items[index]))
-      this.dataset.add(this.factory.quad(bnode, this.factory.term('rdf:rest'), this._createRDFListNode(items, index + 1)))
-      return bnode
-    }
   }
 }
 
@@ -88,17 +57,6 @@ class RDFLibGraphIterator {
       return this.ss[this.index++]
     }
   }
-}
-
-function ensureBlankId (component) {
-  if (component.termType === 'BlankNode') {
-    if (typeof (component.value) !== 'string') {
-      component.value = '_:' + component.id
-    }
-    return component
-  }
-
-  return component
 }
 
 module.exports.RDFLibGraph = RDFLibGraph


### PR DESCRIPTION
I don't think it is the responsibility of the library to make sure that the quads it receives are correct, or to offer easier creation of boolean/list values.