### PR TITLE
Mitigate conflicting blank node IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ## Next version (TBA)
 
-*
+
+## 0.1.3 (2020-04-23)
+
+* Mitigate conflicting blank node issue when using default data factory (#25)
 
 
 ## 0.1.2 (2020-04-21)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2275,6 +2275,12 @@
       "integrity": "sha512-EPaniuSPI+f66F8MP3GPXI3CA4cgSaA688PGUEs1Q5qyeAf/yIhe/8WbDV5+Hnmn8/ewcP7qYY6vfVnjbL5jcg==",
       "dev": true
     },
+    "nanoid": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.3.tgz",
+      "integrity": "sha512-Zw8rTOUfh6FlKgkEbHiB1buOF2zOPOQyGirABUWn+9Z7m9PpyoLVkh6Ksc53vBjndINQ2+9LfRPaHxb/u45EGg==",
+      "dev": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "debug": "^4.1.1",
     "get-stream": "^5.1.0",
     "mocha": "^7.1.1",
+    "nanoid": "3.1.3",
     "nyc": "^15.0.1",
     "rdf-ext": "^1.3.0",
     "rdf-utils-dataset": "1.1.0",

--- a/scripts/dataset-serializer.js
+++ b/scripts/dataset-serializer.js
@@ -1,3 +1,4 @@
+const { nanoid } = require('nanoid')
 
 function serializerTerm (term) {
   if (term.termType === 'BlankNode') {
@@ -42,12 +43,16 @@ function serializeQuads (quads) {
     if (quad.object.termType === 'BlankNode') blankNodes.add(quad.object.value)
   }
 
+  // Transform blank nodes to ad-hoc named nodes to avoid conflicts
+  const blankPrefix = 'urn:rdf-validate-shacl:blank-'
+  const blankURI = () => `${blankPrefix}${nanoid()}`
+
   return [
     '/* This file was automatically generated. Do not edit by hand. */',
     '',
     'module.exports = (factory) => {',
     '  const blankNodes = {',
-    [...blankNodes].map(id => `    '${id}': factory.blankNode()`).join(',\n'),
+    [...blankNodes].map(id => `    '${id}': factory.namedNode('${blankURI()}')`).join(',\n'),
     '  };',
     '',
     '  return [',

--- a/src/vocabularies/shacl.js
+++ b/src/vocabularies/shacl.js
@@ -2,13 +2,13 @@
 
 module.exports = (factory) => {
   const blankNodes = {
-    'b1_c14n3': factory.blankNode(),
-    'b1_c14n6': factory.blankNode(),
-    'b1_c14n0': factory.blankNode(),
-    'b1_c14n1': factory.blankNode(),
-    'b1_c14n5': factory.blankNode(),
-    'b1_c14n2': factory.blankNode(),
-    'b1_c14n4': factory.blankNode()
+    'b0_c14n3': factory.namedNode('urn:rdf-validate-shacl:blank-ICrbDblpRlstcUSwjBAYZ'),
+    'b0_c14n6': factory.namedNode('urn:rdf-validate-shacl:blank-pFK9KYtN26DN0NMXyH8Ar'),
+    'b0_c14n0': factory.namedNode('urn:rdf-validate-shacl:blank-78BxHlZRiJnXywWTF5cqq'),
+    'b0_c14n1': factory.namedNode('urn:rdf-validate-shacl:blank-x54-DFCLtSR8nEZND8Bk3'),
+    'b0_c14n5': factory.namedNode('urn:rdf-validate-shacl:blank-31XwBcULxRTIx9l5dbYMx'),
+    'b0_c14n2': factory.namedNode('urn:rdf-validate-shacl:blank-JIQGzDSBoYQOBoFXDRJb9'),
+    'b0_c14n4': factory.namedNode('urn:rdf-validate-shacl:blank-DzoWy3baN0DSUzrH2JFJ8')
   };
 
   return [
@@ -33,7 +33,7 @@ module.exports = (factory) => {
     factory.quad(
       factory.namedNode('http://www.w3.org/ns/shacl#'),
       factory.namedNode('http://www.w3.org/ns/shacl#declare'),
-      blankNodes['b1_c14n3'],
+      blankNodes['b0_c14n3'],
       factory.namedNode('http://www.w3.org/ns/shacl#')
     ),
     factory.quad(
@@ -1857,7 +1857,7 @@ module.exports = (factory) => {
     factory.quad(
       factory.namedNode('http://www.w3.org/ns/shacl#NodeKindConstraintComponent-nodeKind'),
       factory.namedNode('http://www.w3.org/ns/shacl#in'),
-      blankNodes['b1_c14n6'],
+      blankNodes['b0_c14n6'],
       factory.namedNode('http://www.w3.org/ns/shacl#')
     ),
     factory.quad(
@@ -6697,87 +6697,87 @@ module.exports = (factory) => {
       factory.namedNode('http://www.w3.org/ns/shacl#')
     ),
     factory.quad(
-      blankNodes['b1_c14n0'],
+      blankNodes['b0_c14n0'],
       factory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'),
       factory.namedNode('http://www.w3.org/ns/shacl#BlankNodeOrIRI'),
       factory.namedNode('http://www.w3.org/ns/shacl#')
     ),
     factory.quad(
-      blankNodes['b1_c14n0'],
+      blankNodes['b0_c14n0'],
       factory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'),
-      blankNodes['b1_c14n1'],
+      blankNodes['b0_c14n1'],
       factory.namedNode('http://www.w3.org/ns/shacl#')
     ),
     factory.quad(
-      blankNodes['b1_c14n1'],
+      blankNodes['b0_c14n1'],
       factory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'),
       factory.namedNode('http://www.w3.org/ns/shacl#BlankNodeOrLiteral'),
       factory.namedNode('http://www.w3.org/ns/shacl#')
     ),
     factory.quad(
-      blankNodes['b1_c14n1'],
+      blankNodes['b0_c14n1'],
       factory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'),
-      blankNodes['b1_c14n5'],
+      blankNodes['b0_c14n5'],
       factory.namedNode('http://www.w3.org/ns/shacl#')
     ),
     factory.quad(
-      blankNodes['b1_c14n2'],
+      blankNodes['b0_c14n2'],
       factory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'),
       factory.namedNode('http://www.w3.org/ns/shacl#Literal'),
       factory.namedNode('http://www.w3.org/ns/shacl#')
     ),
     factory.quad(
-      blankNodes['b1_c14n2'],
+      blankNodes['b0_c14n2'],
       factory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'),
-      blankNodes['b1_c14n0'],
+      blankNodes['b0_c14n0'],
       factory.namedNode('http://www.w3.org/ns/shacl#')
     ),
     factory.quad(
-      blankNodes['b1_c14n3'],
+      blankNodes['b0_c14n3'],
       factory.namedNode('http://www.w3.org/ns/shacl#namespace'),
       factory.literal(`http://www.w3.org/ns/shacl#`, factory.namedNode('http://www.w3.org/2001/XMLSchema#string')),
       factory.namedNode('http://www.w3.org/ns/shacl#')
     ),
     factory.quad(
-      blankNodes['b1_c14n3'],
+      blankNodes['b0_c14n3'],
       factory.namedNode('http://www.w3.org/ns/shacl#prefix'),
       factory.literal(`sh`, factory.namedNode('http://www.w3.org/2001/XMLSchema#string')),
       factory.namedNode('http://www.w3.org/ns/shacl#')
     ),
     factory.quad(
-      blankNodes['b1_c14n4'],
+      blankNodes['b0_c14n4'],
       factory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'),
       factory.namedNode('http://www.w3.org/ns/shacl#IRI'),
       factory.namedNode('http://www.w3.org/ns/shacl#')
     ),
     factory.quad(
-      blankNodes['b1_c14n4'],
+      blankNodes['b0_c14n4'],
       factory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'),
-      blankNodes['b1_c14n2'],
+      blankNodes['b0_c14n2'],
       factory.namedNode('http://www.w3.org/ns/shacl#')
     ),
     factory.quad(
-      blankNodes['b1_c14n5'],
+      blankNodes['b0_c14n5'],
       factory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'),
       factory.namedNode('http://www.w3.org/ns/shacl#IRIOrLiteral'),
       factory.namedNode('http://www.w3.org/ns/shacl#')
     ),
     factory.quad(
-      blankNodes['b1_c14n5'],
+      blankNodes['b0_c14n5'],
       factory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'),
       factory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'),
       factory.namedNode('http://www.w3.org/ns/shacl#')
     ),
     factory.quad(
-      blankNodes['b1_c14n6'],
+      blankNodes['b0_c14n6'],
       factory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'),
       factory.namedNode('http://www.w3.org/ns/shacl#BlankNode'),
       factory.namedNode('http://www.w3.org/ns/shacl#')
     ),
     factory.quad(
-      blankNodes['b1_c14n6'],
+      blankNodes['b0_c14n6'],
       factory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'),
-      blankNodes['b1_c14n4'],
+      blankNodes['b0_c14n4'],
       factory.namedNode('http://www.w3.org/ns/shacl#')
     )
   ]


### PR DESCRIPTION
Conflicting blank node IDs (#25) can occur between the dataset containing user-defined shapes and the quads that contain the SHACL ontology when:
1. User doesn't provide to `SHACLValidator` the factory that was used to generate their shapes dataset.
2. User uses N3.js to parse their shapes (N3.js currently tracks blank node IDs separately from the data factory).

Even if (2) gets fixed, I think it's worth mitigating (1) in the future. It seems very likely that users will not pass their own factory, especially because most beginners won't even know what a data factory is.
My proposition is to add a "_shacl" suffix to the SHACL ontology blank node IDs to reduce the probability of a conflict.

Note:
Another option that I considered was to deep clone the datasets provided by the user. It would actually *fix* the issue, but would probably have a bad performance impact. Depending on your feedback @bergos, I can still implement that.