### PR TITLE
Return resultSeverity in report result

### DIFF
--- a/src/shapes-graph.js
+++ b/src/shapes-graph.js
@@ -201,6 +201,7 @@ class Shape {
   constructor (context, shapeNode) {
     this.context = context
     this.severity = context.$shapes.cf.node(shapeNode).out(sh.severity).term
+
     if (!this.severity) {
       this.severity = context.factory.ns.sh.Violation
     }

--- a/src/validation-report.js
+++ b/src/validation-report.js
@@ -56,7 +56,7 @@ class ValidationResult {
   }
 
   get severity () {
-    return this.cf.out(sh.severity).term || null
+    return this.cf.out(sh.resultSeverity).term || null
   }
 
   get sourceConstraintComponent () {

--- a/test/data/validation-message/message-from-shape-property-severity.ttl
+++ b/test/data/validation-message/message-from-shape-property-severity.ttl
@@ -1,0 +1,16 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<Alice> a <Person> .
+
+<ShapeWithMessage> a sh:NodeShape ;
+  sh:targetClass <Person> ;
+  sh:property [
+    sh:path <name> ;
+    sh:datatype xsd:string ;
+    sh:minCount 1 ;
+    sh:message "My custom validation message" ;
+    sh:severity sh:Warning ;
+  ] .
+
+sh:MinCountConstraintComponent sh:message "Message on constraint component" .

--- a/test/validation_message_test.js
+++ b/test/validation_message_test.js
@@ -20,6 +20,28 @@ describe('validation messages', () => {
     assert.strictEqual(report.results[0].message[0].value, 'My custom validation message')
   })
 
+  it('Returns sh:Violation as default severity if not specified', async () => {
+    const dataPath = path.join(rootPath, 'message-from-shape-property.ttl')
+    const data = await loadDataset(dataPath)
+    const shapes = data
+
+    const validator = new SHACLValidator(shapes)
+    const report = validator.validate(data)
+
+    assert.strictEqual(report.results[0].severity.value, 'http://www.w3.org/ns/shacl#Violation')
+  })
+
+  it('Returns shape-specified severity when specified', async () => {
+    const dataPath = path.join(rootPath, 'message-from-shape-property-severity.ttl')
+    const data = await loadDataset(dataPath)
+    const shapes = data
+
+    const validator = new SHACLValidator(shapes)
+    const report = validator.validate(data)
+
+    assert.strictEqual(report.results[0].severity.value, 'http://www.w3.org/ns/shacl#Warning')
+  })
+
   it('Returns message from validator if provided (and no message on shape)', async () => {
     const dataPath = path.join(rootPath, 'message-from-validator.ttl')
     const data = await loadDataset(dataPath)

--- a/test/validation_report_tests.js
+++ b/test/validation_report_tests.js
@@ -144,7 +144,7 @@ describe('ValidationResult', () => {
       RDF.quad(resultNode, sh.resultMessage, RDF.literal('result message')),
       RDF.quad(resultNode, sh.resultPath, RDF.namedNode('result path')),
       RDF.quad(resultNode, sh.focusNode, RDF.namedNode('focus node')),
-      RDF.quad(resultNode, sh.severity, sh.Violation),
+      RDF.quad(resultNode, sh.resultSeverity, sh.Violation),
       RDF.quad(resultNode, sh.sourceShape, RDF.namedNode('source shape')),
       RDF.quad(resultNode, sh.sourceConstraintComponent, RDF.namedNode('source constraint component'))
     ]


### PR DESCRIPTION
* updated severity property to return resultSeverity rather than severity
* added 2 tests for default severity and shape-specified severity
* all tests pass - linter passes