### PR TITLE
Fix multi level sublcass inheritance

### DIFF
--- a/src/rdflib-graph.js
+++ b/src/rdflib-graph.js
@@ -38,7 +38,15 @@ class RDFLibGraph {
       .in(rdfs.subClassOf)
       .terms
 
-    return new NodeSet(subclasses)
+    const transubclasses = subclasses.reduce((acc, cls) => {
+      const scs = this.getSubClassesOf(cls)
+
+      acc.addAll(scs)
+
+      return acc
+    }, new NodeSet())
+
+    return new NodeSet([...subclasses, ...transubclasses])
   }
 
   isInstanceOf ($instance, $class) {

--- a/test/data/data-shapes/custom/manifest.ttl
+++ b/test/data/data-shapes/custom/manifest.ttl
@@ -7,4 +7,5 @@
 	rdfs:label "Custom tests to complete the official test suite" ;
 	mf:include <closed-false.ttl> ;
 	mf:include <uniqueLang-false.ttl> ;
+	mf:include <multiInheritance.ttl> ;
 	.

--- a/test/data/data-shapes/custom/multiInheritance.ttl
+++ b/test/data/data-shapes/custom/multiInheritance.ttl
@@ -1,0 +1,73 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://example.org#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <multiInheritance>
+    ) ;
+.
+<multiInheritance>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of multi level subclasses in shapes" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+        a sh:ValidationResult ;
+        sh:resultSeverity sh:Violation ;
+        sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+        sh:sourceShape ex:prop ;
+        sh:focusNode ex:InvalidMidInstance ;
+        sh:resultPath ex:name ;
+      ],[
+        a sh:ValidationResult ;
+        sh:resultSeverity sh:Violation ;
+        sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+        sh:sourceShape ex:prop ;
+        sh:focusNode ex:InvalidBottomInstance ;
+        sh:resultPath ex:name ;
+      ];
+  ] ;
+.
+
+ex:InvalidMidInstance
+  a ex:MidShape;
+.
+
+ex:InvalidBottomInstance
+  a ex:BottomShape;
+.
+
+ex:prop sh:path ex:name ;
+  sh:minCount 1;
+.
+
+ex:TopShape
+    a sh:NodeShape, rdfs:Class;
+    sh:targetClass ex:TopShape ;
+    sh:property ex:prop;
+.
+
+ex:MidShape
+    a sh:NodeShape, rdfs:Class;
+    rdfs:subClassOf ex:TopShape ;
+    sh:targetClass ex:MidShape ;
+.
+
+ex:BottomShape
+    a sh:NodeShape, rdfs:Class;
+    rdfs:subClassOf ex:MidShape ;
+    sh:targetClass ex:BottomShape;
+.


### PR DESCRIPTION
Hi,

this is related to issue #41.

As pointed out there `getSubClassesOf ` is not resolving transitive subclasses. I made a small fix and an additional test that verifies the behaviour and that can be replicated on https://shacl.org/playground/ (I do not know if that is the intended place for such kinds of tests though) .