### PR TITLE
fix: duplicate validation message

### DIFF
--- a/src/validation-engine.js
+++ b/src/validation-engine.js
@@ -76,7 +76,6 @@ class ValidationEngine {
         this.addResultPropertyDeep(result, sh.resultPath, constraint.shape.path, true)
       }
       this.addResultProperty(result, sh.resultMessage, this.factory.literal(obj, xsd.string))
-      this.createResultMessages(result, constraint)
       return true
     } else if (typeof obj === 'object') {
       if (this.recordErrorsLevel > 0) {


### PR DESCRIPTION
Fix duplicate validation messages when validator returns a custom message. This was happening only for `uniqueLang` by default.