### PR TITLE
fix: do not fail validation for target nodes that don't exist

### DIFF
--- a/src/shapes-graph.js
+++ b/src/shapes-graph.js
@@ -273,7 +273,14 @@ class Shape {
       results.addAll(getInstancesOf(dataGraph.node(targetClass), ns))
     })
 
-    results.addAll(this.shapeNodePointer.out(sh.targetNode).terms)
+    const targetNodes = this.shapeNodePointer.out(sh.targetNode).terms
+      // Ensure the node exists in data graph before considering it as a validatable target node
+      .filter(targetNode => (
+        dataGraph.dataset.match(targetNode).length > 0 ||
+        dataGraph.dataset.match(null, targetNode).length > 0 ||
+        dataGraph.dataset.match(null, null, targetNode).length > 0
+      ))
+    results.addAll(targetNodes)
 
     this.shapeNodePointer
       .out(sh.targetSubjectsOf)

--- a/test/data/data-shapes/custom/manifest.ttl
+++ b/test/data/data-shapes/custom/manifest.ttl
@@ -9,4 +9,5 @@
 	mf:include <uniqueLang-false.ttl> ;
 	mf:include <multiLevelInheritance.ttl> ;
 	mf:include <multiLevelInheritanceWithImplicitTarget.ttl> ;
+	mf:include <targetNodeDoesNotExist.ttl> ;
 	.

--- a/test/data/data-shapes/custom/targetNodeDoesNotExist-data.ttl
+++ b/test/data/data-shapes/custom/targetNodeDoesNotExist-data.ttl
@@ -1,0 +1,1 @@
+# This data graph is empty on purpose

--- a/test/data/data-shapes/custom/targetNodeDoesNotExist.ttl
+++ b/test/data/data-shapes/custom/targetNodeDoesNotExist.ttl
@@ -1,0 +1,32 @@
+@prefix ex: <http://datashapes.org/sh/tests/core/property/uniqueLang-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+  rdf:type mf:Manifest ;
+  mf:entries ( <target-node-does-not-exist> ) ;
+.
+
+<target-node-does-not-exist>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:targetNode absent from data graph" ;
+  mf:action [
+    sht:dataGraph <targetNodeDoesNotExist-data.ttl> ;
+    sht:shapesGraph <> ;
+  ] ;
+  mf:result [
+    rdf:type sh:ValidationReport ;
+    sh:conforms "true"^^xsd:boolean ;
+  ] ;
+  mf:status sht:proposed ;
+.
+
+ex:MyShape
+  rdf:type sh:NodeShape ;
+  sh:targetNode ex:Instance1 ;
+  sh:class ex:TheClass ;
+.


### PR DESCRIPTION
Fixes #66

A target node that doesn't exist in the data graph at all should not cause a validation failure.