### PR TITLE
Provide nested results of sh:node via sh:detail

### DIFF
--- a/src/validation-report.js
+++ b/src/validation-report.js
@@ -68,6 +68,11 @@ class ValidationResult {
   get value () {
     return this.pointer.out(this.ns.sh.value).term || null
   }
+
+  get detail () {
+    return this.pointer.out(this.ns.sh.detail).map(detailResult =>
+      new ValidationResult(detailResult, this.ns))
+  }
 }
 
 module.exports = ValidationReport

--- a/test/data-shapes_tests.js
+++ b/test/data-shapes_tests.js
@@ -120,6 +120,11 @@ function normalizeReport (report, expectedReport) {
     report.out(sh.result).deleteOut(sh.resultMessage)
   }
 
+  // Delete nested results
+  report.out(sh.result).out(sh.detail).out().deleteOut()
+  report.out(sh.result).out(sh.detail).deleteOut()
+  report.out(sh.result).deleteOut(sh.detail)
+
   // Split shared blank nodes into distinct blank node structures
   splitSharedBlankNodes(report.dataset)
 }

--- a/test/data-shapes_tests.js
+++ b/test/data-shapes_tests.js
@@ -27,6 +27,8 @@ before(async () => {
 
   describe('Official data-shapes test suite', () => {
     testCases.forEach((testCase) => it(testCase.label, async function () {
+      this.timeout(3000)
+
       if (SKIPPED.includes(testCase.node.value)) {
         this.skip()
       } else {

--- a/test/nested-shape.ttl
+++ b/test/nested-shape.ttl
@@ -1,0 +1,40 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/shacl-test/> .
+
+ex:InvalidInstance1
+  ex:first ex:InvalidInstance1_first ;
+.
+
+ex:InvalidInstance1_first
+  ex:name "Hello", "Hi" ;
+.
+
+ex:TestShape
+  a sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:property ex:TestShape-first ;
+  sh:targetNode ex:InvalidInstance1 ;
+.
+
+ex:TestShape-first
+  sh:path ex:first ;
+  sh:node ex:NestedShape ;
+.
+
+ex:NestedShape
+  sh:property ex:Nested_name ;
+  sh:property ex:Nested_address ;
+.
+
+ex:Nested_name
+  a sh:PropertyShape ;
+  sh:path ex:name ;
+  sh:maxCount 1 ;
+.
+
+ex:Nested_address
+  a sh:PropertyShape ;
+  sh:path ex:address ;
+  sh:minCount 1 ;
+.

--- a/test/nested_results_test.js
+++ b/test/nested_results_test.js
@@ -1,0 +1,32 @@
+/* eslint-env mocha */
+const path = require('path')
+const assert = require('assert')
+const { loadDataset } = require('./utils')
+const rdf = require('rdf-ext')
+
+const SHACLValidator = require('../index')
+const rootPath = path.join(__dirname, '.')
+
+describe('nested results', () => {
+  it('provides nested validation results using `sh:detail`', async () => {
+    const dataPath = path.join(rootPath, 'nested-shape.ttl')
+    const data = await loadDataset(dataPath)
+    const shapes = data
+
+    const validator = new SHACLValidator(shapes, { factory: rdf })
+    const report = validator.validate(data)
+
+    assert.strictEqual(report.results.length, 1)
+    const result = report.results[0]
+    assert.strictEqual(result.message.length, 1)
+    assert.strictEqual(result.message[0].value, 'Value does not have shape <http://example.org/shacl-test/NestedShape>')
+
+    assert.strictEqual(result.detail.length, 2)
+    const nestedResult0 = result.detail[0]
+    assert.strictEqual(nestedResult0.path.value, 'http://example.org/shacl-test/name')
+    assert.strictEqual(nestedResult0.message[0].value, 'More than 1 values')
+    const nestedResult1 = result.detail[1]
+    assert.strictEqual(nestedResult1.path.value, 'http://example.org/shacl-test/address')
+    assert.strictEqual(nestedResult1.message[0].value, 'Less than 1 values')
+  })
+})

--- a/test/validation_report_tests.js
+++ b/test/validation_report_tests.js
@@ -113,6 +113,11 @@ describe('ValidationResult', () => {
           .addOut(sh.sourceShape, RDF.namedNode('source shape'))
           .addOut(sh.sourceConstraintComponent, RDF.namedNode('source constraint component'))
           .addOut(sh.value, RDF.namedNode('value'))
+          .addOut(sh.detail, nested => {
+            nested.addOut(rdf.type, sh.ValidationResult)
+              .addOut(sh.resultPath, RDF.namedNode('nested result path'))
+              .addOut(sh.resultMessage, RDF.literal('nested result message'))
+          })
       })
     const report = new ValidationReport(pointer)
 
@@ -144,6 +149,13 @@ describe('ValidationResult', () => {
 
     it('returns value term', () => {
       assert.deepStrictEqual(result.value, RDF.namedNode('value'))
+    })
+
+    it('returns detail results', () => {
+      const detail = result.detail
+      const nestedResult = detail[0]
+      assert.deepStrictEqual(nestedResult.path, RDF.namedNode('nested result path'))
+      assert.deepStrictEqual(nestedResult.message, [RDF.literal('nested result message')])
     })
   })
 })


### PR DESCRIPTION
Provide nested results of `sh:node` using `sh:detail` of root `ValidationResult`.