### PR TITLE
message for sh:xone

### DIFF
--- a/src/validators.js
+++ b/src/validators.js
@@ -406,12 +406,22 @@ function validateXone(context, focusNode, valueNode, constraint) {
   const { sh } = context.ns
   const xoneNode = constraint.getParameterValue(sh.xone)
   const shapes = rdfListToArray(context.$shapes.node(xoneNode))
-  const conformsCount = shapes
-    .map(shape => context.nodeConformsToShape(valueNode, shape))
-    .filter(Boolean)
-    .length
 
-  return conformsCount === 1
+  const conformsPositions = []
+  for (let i = 0; i < shapes.length; i++) {
+    const shape = shapes[i]
+    if (context.nodeConformsToShape(valueNode, shape)) {
+      conformsPositions.push(i + 1)
+    }
+  }
+
+  if (conformsPositions.length === 0) {
+    return ['no shapes matched']
+  }
+  if (conformsPositions.length > 1) {
+    return ['multiple matches, at positions ' + conformsPositions.join(', ')]
+  }
+  return []
 }
 
 // Private helper functions

--- a/test/data/validation-message/message-for-xone.ttl
+++ b/test/data/validation-message/message-for-xone.ttl
@@ -1,0 +1,12 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+<Alice> a <Person> , <Category1> , <Category3> .
+
+<ShapeWithXone> a sh:NodeShape ;
+  sh:targetClass <Person> ;
+  sh:xone (
+      [ sh:class <Category1> ]
+      [ sh:class <Category2> ]
+      [ sh:class <Category3> ]
+    ) ;
+  .

--- a/test/validation_message_test.js
+++ b/test/validation_message_test.js
@@ -102,4 +102,17 @@ describe('validation messages', () => {
     assert.strictEqual(report.results[0].message.length, 1)
     assert.strictEqual(report.results[0].message[0].value, 'Value is not one of the allowed values: a, b, c ... (and 2 more)')
   })
+
+  it('Lists conforming shapes in message for xone', async () => {
+    const dataPath = path.join(rootPath, 'message-for-xone.ttl')
+    const data = await loadDataset(dataPath)
+    const shapes = data
+
+    const validator = new SHACLValidator(shapes)
+    const report = validator.validate(data)
+
+    assert.strictEqual(report.results.length, 1)
+    assert.strictEqual(report.results[0].message.length, 1)
+    assert.strictEqual(report.results[0].message[0].value, 'multiple matches, at positions 1, 3')
+  })
 })


### PR DESCRIPTION
A result message for `sh:xone` violations is added, indicating which shapes conformed.

The implementation may be refined (for example we may use [Intl.PluralRules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules) for ordinal numbers) and extended to other constraints (`sh:and`), but I'd like some feedback (@ktk, @tpluscode and anybody interested) about the usefulness of this.