### PR TITLE
fix: using property shapes in logical constraints

### DIFF
--- a/.changeset/selfish-pants-grin.md
+++ b/.changeset/selfish-pants-grin.md
@@ -1,0 +1,5 @@
+---
+"rdf-validate-shacl": patch
+---
+
+Gracefully handle Property Shapes used inside logical constraints (fixes #140)

--- a/index.js
+++ b/index.js
@@ -67,8 +67,19 @@ class SHACLValidator {
   }
 
   // Exposed to be available from validation functions as `SHACL.nodeConformsToShape`
-  nodeConformsToShape(focusNode, shapeNode, engine = this.validationEngine.clone()) {
-    const shape = this.shapesGraph.getShape(shapeNode)
+  nodeConformsToShape(focusNode, shapeNode, propertyPathOrEngine) {
+    let engine
+    let shape = this.shapesGraph.getShape(shapeNode)
+
+    if (propertyPathOrEngine && 'termType' in propertyPathOrEngine) {
+      engine = this.validationEngine.clone({
+        propertyPath: propertyPathOrEngine,
+        recordErrorsLevel: this.validationEngine.recordErrorsLevel,
+      })
+      shape = shape.overridePath(propertyPathOrEngine)
+    } else {
+      engine = propertyPathOrEngine || this.validationEngine.clone()
+    }
     try {
       this.depth++
       const foundViolations = engine.validateNodeAgainstShape(focusNode, shape, this.$data)
@@ -78,7 +89,7 @@ class SHACLValidator {
     }
   }
 
-  validateNodeAgainstShape (focusNode, shapeNode) {
+  validateNodeAgainstShape(focusNode, shapeNode) {
     return this.nodeConformsToShape(focusNode, shapeNode, this.validationEngine)
   }
 }

--- a/src/shapes-graph.js
+++ b/src/shapes-graph.js
@@ -109,6 +109,10 @@ class Constraint {
     return this.paramValue || this.shapeNodePointer.out(param).term
   }
 
+  get pathObject() {
+    return this.shape.pathObject
+  }
+
   get validationFunction() {
     return this.shape.isPropertyShape
       ? this.component.propertyValidationFunction
@@ -231,7 +235,6 @@ class Shape {
     this.severity = this.shapeNodePointer.out(sh.severity).term || sh.Violation
     this.deactivated = this.shapeNodePointer.out(sh.deactivated).value === 'true'
     this.path = this.shapeNodePointer.out(sh.path).term
-    this.isPropertyShape = this.path != null
     this._pathObject = undefined
 
     this.constraints = []
@@ -249,6 +252,16 @@ class Shape {
         }
       }
     })
+  }
+
+  get isPropertyShape() {
+    return this.path != null
+  }
+
+  overridePath(path) {
+    const shape = new Shape(this.context, this.shapeNode)
+    shape.path = path
+    return shape
   }
 
   /**

--- a/src/validation-engine.js
+++ b/src/validation-engine.js
@@ -12,15 +12,21 @@ class ValidationEngine {
     this.factory = context.factory
     this.maxErrors = options.maxErrors
     this.maxNodeChecks = options.maxNodeChecks === undefined ? defaultMaxNodeChecks : options.maxNodeChecks
+    this.propertyPath = options.propertyPath
     this.initReport()
-    this.recordErrorsLevel = 0
+    this.recordErrorsLevel = options.recordErrorsLevel || 0
     this.violationsCount = 0
     this.validationError = null
-    this.nestedResults = {}
+    this.nestedResults = options.nestedResults || {}
   }
 
-  clone() {
-    return new ValidationEngine(this.context, { maxErrors: this.maxErrors, maxNodeChecks: this.maxNodeChecks })
+  clone({ propertyPath, recordErrorsLevel } = {}) {
+    return new ValidationEngine(this.context, {
+      maxErrors: this.maxErrors,
+      maxNodeChecks: this.maxNodeChecks,
+      propertyPath,
+      recordErrorsLevel,
+    })
   }
 
   initReport() {

--- a/src/validators.js
+++ b/src/validators.js
@@ -9,7 +9,13 @@ function validateAnd(context, focusNode, valueNode, constraint) {
   const andNode = constraint.getParameterValue(sh.and)
   const shapes = rdfListToArray(context.$shapes.node(andNode))
 
-  return shapes.every((shape) => context.nodeConformsToShape(valueNode, shape))
+  return shapes.every((shape) => {
+    if (constraint.shape.isPropertyShape) {
+      return context.nodeConformsToShape(focusNode, shape, constraint.pathObject)
+    }
+
+    return context.nodeConformsToShape(valueNode, shape)
+  })
 }
 
 function validateClass(context, focusNode, valueNode, constraint) {
@@ -226,7 +232,7 @@ function validateMaxLength(context, focusNode, valueNode, constraint) {
 
 function validateMinCountProperty(context, focusNode, valueNode, constraint) {
   const { sh } = context.ns
-  const path = constraint.shape.pathObject
+  const path = constraint.pathObject
   const count = getPathObjects(context.$data, focusNode, path).length
   const minCountNode = constraint.getParameterValue(sh.minCount)
 

--- a/test/data/data-shapes/custom/and-minCount.ttl
+++ b/test/data/data-shapes/custom/and-minCount.ttl
@@ -1,0 +1,76 @@
+PREFIX schema: <http://schema.org/>
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/uniqueLang-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+    rdf:type mf:Manifest ;
+    mf:entries
+        (
+            <and-minCount>
+        ) ;
+.
+<and-minCount>
+    rdf:type sht:Validate ;
+    rdfs:label "Test of unexpected validation error as reported in issue zazuko/rdf-validate-shacl#140" ;
+    mf:action
+        [
+            sht:dataGraph <> ;
+            sht:shapesGraph <> ;
+        ] ;
+    mf:result
+        [
+            rdf:type sh:ValidationReport ;
+            sh:conforms "false"^^xsd:boolean ;
+            sh:result
+
+                [
+                    rdf:type sh:ValidationResult ;
+                    sh:focusNode ex:Instance ;
+                    sh:resultPath schema:age ;
+                    sh:resultSeverity sh:Violation ;
+                    sh:sourceConstraintComponent sh:AndConstraintComponent ;
+                    sh:sourceShape ex:age ;
+                    sh:value 18 ;
+                ],
+                [
+                    rdf:type sh:ValidationResult ;
+                    sh:focusNode ex:Instance ;
+                    sh:resultPath schema:name ;
+                    sh:resultSeverity sh:Violation ;
+                    sh:sourceConstraintComponent sh:AndConstraintComponent ;
+                    sh:sourceShape ex:name ;
+                    sh:value "John" ;
+                ] ;
+        ] ;
+    mf:status sht:proposed ;
+.
+ex:Instance
+    schema:age 18 ;
+    schema:name "John" ;
+    a schema:Person ;
+.
+ex:PersonAddressShape
+    a sh:NodeShape ;
+    sh:targetClass schema:Person ;
+    sh:property ex:name, ex:age .
+
+ex:ps1 a sh:PropertyShape ;
+    sh:minCount 2 ;
+.
+
+ex:name a sh:PropertyShape ;
+    sh:path schema:name ;
+    sh:and ( ex:ps1 ) ;
+.
+
+ex:age a sh:PropertyShape ;
+    sh:path schema:age ;
+    sh:and ( ex:ps1 ) ;
+.

--- a/test/data/data-shapes/custom/manifest.ttl
+++ b/test/data/data-shapes/custom/manifest.ttl
@@ -12,4 +12,5 @@
 	mf:include <targetNodeDoesNotExist.ttl> ;
 	mf:include <lessThan-moreTypes.ttl> ;
 	mf:include <circularReferences.ttl> ;
+	mf:include <and-minCount.ttl> ;
 	.


### PR DESCRIPTION
This improves the handling of Property Shapes nested inside logical constraints, such as `sh:and`

```turtle
@prefix sh: <http://www.w3.org/ns/shacl#> .
@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@prefix schema: <http://schema.org/> .
@prefix ex: <http://example.com/> .

ex:PersonAddressShape
	a sh:NodeShape ;
	sh:targetClass schema:Person ;
	sh:property ex:ps3 .

ex:ps1	a sh:PropertyShape ;
		sh:minCount 1 .

ex:ps3	a sh:PropertyShape ;
		sh:path schema:age ;
		sh:and ( ex:ps1 ) .
```

By the SHACL spec, `ex:ps1` is not a valid Property Shape because it lacks `sh:path`. However, since the Java TopQuadrant implementation handle such cases we could also try to support them