### PR TITLE
Remove trailing whitespace

### DIFF
--- a/.github/workflows/benchmarks-pr.yml
+++ b/.github/workflows/benchmarks-pr.yml
@@ -19,7 +19,7 @@ jobs:
       - run: npm ci
       - name: Track PR Benchmarks with Bencher
         run: |
-          bencher run \         
+          bencher run \
           --project rdf-validate-shacl \
           --token '${{ secrets.BENCHER_API_TOKEN }}' \
           --branch "$GITHUB_HEAD_REF" \


### PR DESCRIPTION
Remove trailing whitespace from `bencher run` command after the escape character (`\` ) so it operates on the newline (`\n`) instead of a space (` `).

If you use VSCode, I highly recommend this extension: https://marketplace.visualstudio.com/items?itemName=shardulm94.trailing-spaces